### PR TITLE
Feature/benchmarks and generics

### DIFF
--- a/Grylloparse/Makefile
+++ b/Grylloparse/Makefile
@@ -7,7 +7,7 @@ AR = ar
 CXXFLAGS= -std=c++14 
 LDFLAGS= 
 
-TEST_CXXFLAGS= -std=c++14 
+TEST_CXXFLAGS= -std=c++14 -g -O0 -fno-inline-functions
 TEST_LDFLAGS=
 TEST_EXEC_ARGS=
 

--- a/Grylloparse/src/benchmark/lexerRunners.cpp
+++ b/Grylloparse/src/benchmark/lexerRunners.cpp
@@ -2,69 +2,95 @@
 #include <sstream>
 #include <gryltools/execution_time.hpp>
 #include "grylloparse.hpp"
-#include "lexer.hpp"
+
+// Include source so we can use the implementation.
+#include "../lexer.cpp"
+
+/*! Benchmark tests the LexerImpl's Dedicated runner (regex_iterator loop)
+ *  vs Standard runner (repeatedly calling one-token getNextTokenPriv).
+ *
+ *  - We find out that on buffer sizes high enough, the execution time of 
+ *    both runners becomes nearly the same.
+ *  - at BUFFSIZE = 2048, ITERATIONS = 1000, and the test program as below,
+ *    the exectution time of each runner is ~0.8 seconds. 
+ *    (So runner's single runtime is ~0.0008 sec.)
+ *
+ *  - However, with smaller buffer sizes the execution times grow, but not dramatically.
+ *    Even at BUFFSIZE = 5, it takes only 2x longer than with BUFFSIZE = 2048.
+ *    And, both runners still perform basically the same.
+ *
+ *  CONCLUSION: it's pointless to use a dedicated runner. Just use the standard
+ *    single-token repeated runner. This save much code, and improves flexibility,
+ *    when using custom tokenizers.
+ */ 
 
 const char* testLexics =
 "<ident> := \"\\w+\" ;\n"
 "<operator> := \"[;=+\\-\\*/\\[\\]{}<>%]\" ;\n"
 ;
-//"<ignore> := \"[abc]\" ;"
-//"<regex_delim> := <operator> | \"\\w\" ;"
+
+const size_t ITERATIONS = 1000;
+const size_t BUFFSIZE = 2048;
+
+const char* testProgram = 
+"aaaaaabbbbbbbbbbb;11;babababa;+++++++++ahuibd\n afjba  12 bajbsdjk"
+"aaaaaabbbbbbbbbbb;11;babababa;+++++++++ahuibd\n afjba  12 bajbsdjk"
+"aaaaaabbbbbbbbbbb;11;babababa;+++++++++ahuibd\n afjba  12 bajbsdjk"
+"aaaaaabbbbbbbbbbb;11;babababa;+++++++++ahuibd\n afjba  12 bajbsdjk"
+"aaaaaabbbbbbbbbbb;11;babababa;+++++++++ahuibd\n afjba  12 bajbsdjk"
+"aaaaaabbbbbbbbbbb;11;babababa;+++++++++ahuibd\n afjba  12 bajbsdjk"
+"aaaaaabbbbbbbbbbb;11;babababa;+++++++++ahuibd\n afjba  12 bajbsdjk"
+"aaaaaabbbbbbbbbbb;11;babababa;+++++++++ahuibd\n afjba  12 bajbsdjk"
+"aaaaaabbbbbbbbbbb;11;babababa;+++++++++ahuibd\n afjba  12 bajbsdjk"
+"aaaaaabbbbbbbbbbb;11;babababa;+++++++++ahuibd\n afjba  12 bajbsdjk"
+"aaaaaabbbbbbbbbbb;11;babababa;+++++++++ahuibd\n afjba  12 bajbsdjk"
+"aaaaaabbbbbbbbbbb;11;babababa;+++++++++ahuibd\n afjba  12 bajbsdjk"
+"aaaaaabbbbbbbbbbb;11;babababa;+++++++++ahuibd\n afjba  12 bajbsdjk"
+"aaaaaabbbbbbbbbbb;11;babababa;+++++++++ahuibd\n afjba  12 bajbsdjk"
 ;
 
-//const char* testProgram = "aaaaaabbbbbbbbbbb;11;babababa;+*+*+*ahuibd\n   12{{{}}}bajbsdjk";
-
 int main(int argc, char** argv){
-    std::cout<<"Newt newt!\n";
-    
     // Stringstream for data.
-    /*std::istringstream sstr( testLexics );
+    std::istringstream sstr( testLexics );
 
     // Test the GBNF stuff
     gbnf::GbnfData lexicData;
 
-    std::cout<<"Convering lexic data to GBNF...\n";
-
     gbnf::convertToGbnf( lexicData, sstr );
     gbnf::convertToBNF( lexicData );
      
-    std::cout<<"\nlexicData:\n"<< lexicData <<"\n\n";
+    //std::cout<<"\nlexicData:\n"<< lexicData <<"\n\n";
 
     gparse::RegLexData lexicon( lexicData, true );
 
-    std::cout<<"\n"<< lexicon <<"\n\n";
-    std::cout<<"=========================\n\nTokenizing by Lexics...\n\n";
+    //std::cout<<"\n"<< lexicon <<"\n\n";
 
-    std::istringstream pstream( testProgram );
+    std::cout<<"\n=========================\n\nBenchmarking Dedicated Runner.\n\n";
+    std::cout<<"Execution took " <<
+    gtools::functionExecTimeRepeated( [&](){
+        std::istringstream pstream( testProgram );
+        gparse::LexerImpl lexer( lexicon, pstream, true, 0, true, BUFFSIZE ); 
+        lexer.start();
+    }, ITERATIONS ).count()
+    << " seconds\n";
 
-    gparse::Lexer* lexer = nullptr;
-    
-    if( useMultithreading ){
-        lexer = new gparse::Lexer( lexicon, pstream, true );
-        lexer->start();
-    }
-    else
-        lexer = new gparse::Lexer( lexicon, pstream );
+    std::cout<<"\n=========================\n\nBenchmarking Standard Runner.\n\n";
+    std::cout<<"Execution took " <<
+    gtools::functionExecTimeRepeated( [&](){
+        std::istringstream pstream( testProgram );
+        gparse::LexerImpl lexer( lexicon, pstream, true, 0, false, BUFFSIZE ); 
+        lexer.start();
+    }, ITERATIONS ).count()
+    << " seconds\n";
 
-    std::cout<< "CharByChar:\nExecution took " <<
-    functionExecTimeReturnCallback( readCharByChar, ITERATIONS, [](StreamStats&& st){
-        std::cout<< st <<"\n"; }, CALLBACK_ONLY_AT_THE_END, sstr ).count()
-    << " ms\n";
-
-    std::cout<< "\n\nbuffXtimes:\n" <<
-    functionExecTimeReturnCallback( readBuffered, ITERATIONS, [](StreamStats&& st){
-        std::cout<< st <<"\n"; }, CALLBACK_ONLY_AT_THE_END, sstr, BUFFSIZE ).count()
-    << " ms\n"; 
-
-    if( lexer ){
+    /*if( lexer ){
         gparse::LexicToken tok;
         while( lexer->getNextToken( tok ) ){
             std::cout<< "\nGOT TOKEN!!! : \n"<< tok <<"\n\n";
         }
-
-        delete lexer;
-    }
-    */
+    }*/
 
     return 0;
 }
+
+

--- a/Grylloparse/src/benchmark/lexerRunners.cpp
+++ b/Grylloparse/src/benchmark/lexerRunners.cpp
@@ -4,8 +4,6 @@
 #include "grylloparse.hpp"
 #include "lexer.hpp"
 
-const bool useMultithreading = true;
-
 const char* testLexics =
 "<ident> := \"\\w+\" ;\n"
 "<operator> := \"[;=+\\-\\*/\\[\\]{}<>%]\" ;\n"
@@ -14,15 +12,13 @@ const char* testLexics =
 //"<regex_delim> := <operator> | \"\\w\" ;"
 ;
 
-const char* testProgram = "aaaaaabbbbbbbbbbb;11";
-//"int i = 0;;";
-
+//const char* testProgram = "aaaaaabbbbbbbbbbb;11;babababa;+*+*+*ahuibd\n   12{{{}}}bajbsdjk";
 
 int main(int argc, char** argv){
     std::cout<<"Newt newt!\n";
     
     // Stringstream for data.
-    std::istringstream sstr( testLexics );
+    /*std::istringstream sstr( testLexics );
 
     // Test the GBNF stuff
     gbnf::GbnfData lexicData;
@@ -68,6 +64,7 @@ int main(int argc, char** argv){
 
         delete lexer;
     }
+    */
 
     return 0;
 }

--- a/Grylloparse/src/lexer.cpp
+++ b/Grylloparse/src/lexer.cpp
@@ -41,7 +41,9 @@ class LexerImpl : public BaseLexer
 {
 // Specific constants.
 public:
-    const static size_t BUFFER_SIZE = 5;
+    const static size_t DEFAULT_BUFFSIZE = 5;
+    const static int    DEFAULT_VERBOSITY = 0;
+    const static bool   DEFAULT_UDR = true;
 
     // Token extractor responses.
     // < 0 means fatal error
@@ -63,8 +65,9 @@ private:
     const bool useBlockingQueue;
     
     const bool useLineStats = false;
-    const bool useDedicatedLoopyTokenizer = true;
+    const bool useDedicatedLoopyTokenizer;
 
+    const size_t BUFFER_SIZE;
     const int verbosity = 3;
 
     // Lexic Data (RegLex-format).
@@ -138,16 +141,26 @@ public:
      */ 
     LexerImpl( const RegLexData& lexicData, std::istream& strm, bool useBQ=false, 
                const std::function< int(LexerImpl&, LexicToken&) >& getNxTk = 
-                     std::function< int(LexerImpl&, LexicToken&) >() )
-        : useBlockingQueue( useBQ ), lexics( lexicData ), rdr( strm ), 
+                     std::function< int(LexerImpl&, LexicToken&) >(),
+               size_t _verbosity = DEFAULT_VERBOSITY, 
+               bool _useDedicatedRunner = DEFAULT_UDR, 
+               size_t bufferSize = DEFAULT_BUFFSIZE )
+        : useBlockingQueue( useBQ ), useDedicatedLoopyTokenizer( _useDedicatedRunner ),
+          BUFFER_SIZE( bufferSize ), verbosity( _verbosity ),
+          lexics( lexicData ), rdr( strm ), 
           bQueue( useBQ ? new gtools::BlockingQueue< LexicToken >() : nullptr ),
           getNextTokenPriv( getNxTk )
     { setFunctions(); }
 
     LexerImpl( RegLexData&& lexicData, std::istream& stream, bool useBQ = false,
                std::function< int(LexerImpl&, LexicToken&) >&& getNxTk = 
-                    std::function< int(LexerImpl&, LexicToken&) >() )
-        : useBlockingQueue( useBQ ), lexics( std::move(lexicData) ), rdr( stream ), 
+                    std::function< int(LexerImpl&, LexicToken&) >(),
+               size_t _verbosity = DEFAULT_VERBOSITY, 
+               bool _useDedicatedRunner = DEFAULT_UDR, 
+               size_t bufferSize = DEFAULT_BUFFSIZE ) 
+        : useBlockingQueue( useBQ ), useDedicatedLoopyTokenizer( _useDedicatedRunner ),
+          BUFFER_SIZE( bufferSize ), verbosity( _verbosity ),
+          lexics( std::move(lexicData) ), rdr( stream ), 
           bQueue( useBQ ? new gtools::BlockingQueue< LexicToken >() : nullptr ),
           getNextTokenPriv( std::move( getNxTk ) )
     { setFunctions(); }
@@ -345,7 +358,7 @@ int LexerImpl::getNextTokenPriv_Regexed( LexerImpl& lex, LexicToken& tok ){
                         size_t tokp = (lex.bufferPointer - lex.buffer.c_str()) + m.position();
                         size_t remLen = lex.bufferEnd - tokEnd;
 
-                        std::string remBuff( BUFFER_SIZE, '\0' );
+                        std::string remBuff( lex.BUFFER_SIZE, '\0' );
                         std::memmove( &(remBuff[0]), tokEnd, remLen );
 
                         if( tokp > 0 ){
@@ -406,14 +419,14 @@ int LexerImpl::getNextTokenPriv_Regexed( LexerImpl& lex, LexicToken& tok ){
             size_t curTokStart = (lex.bufferPointer - &(lex.buffer[0])) + m.position();
 
             // If token is longer than half of BUFFER_SIZE, extend the buffer.
-            if( (size_t)(m.length()) > (size_t)(lex.buffer.size() - LexerImpl::BUFFER_SIZE/2) ){
+            if( (size_t)(m.length()) > (size_t)(lex.buffer.size() - lex.BUFFER_SIZE/2) ){
                 if( lex.verbosity > 2 )
                     std::cout<< " Extending Buffer.\n";
 
                 // Move memory to the resized buffer, if the token starts later.
                 if( curTokStart > 0 ){
                     // Create new buffer
-                    std::string tmp( lex.buffer.size() + (LexerImpl::BUFFER_SIZE / 2), '\0' );
+                    std::string tmp( lex.buffer.size() + (lex.BUFFER_SIZE / 2), '\0' );
 
                     // Move data to new buffer.
                     std::memmove( &(tmp[0]), &(lex.buffer[0]) + curTokStart, m.length() );
@@ -422,7 +435,7 @@ int LexerImpl::getNextTokenPriv_Regexed( LexerImpl& lex, LexicToken& tok ){
                     lex.buffer.assign( std::move( tmp ) );
                 }
                 else
-                    lex.buffer.resize( lex.buffer.size() + (LexerImpl::BUFFER_SIZE / 2), '\0' );
+                    lex.buffer.resize( lex.buffer.size() + (lex.BUFFER_SIZE / 2), '\0' );
 
                 // Mark this flag, for buffer eset after valid token is matched.
                 bufferWasExtended = true;
@@ -571,7 +584,7 @@ void LexerImpl::runner_dedicatedIteration( LexerImpl& lex ){
                         tok.data.assign( std::move( lex.buffer ) );
 
                         // Move remaining data to new buffer.
-                        lex.buffer.assign( LexerImpl::BUFFER_SIZE, '\0' );
+                        lex.buffer.assign( lex.BUFFER_SIZE, '\0' );
                         std::memmove( &(lex.buffer[0]), tokEnd, (lex.bufferEnd - tokEnd) );
 
                         // Now we can safely resize the token buffer.
@@ -615,14 +628,14 @@ void LexerImpl::runner_dedicatedIteration( LexerImpl& lex ){
             fetchOffset = tokEnd - lex.bufferPointer;
 
             // If token is longer than half of BUFFER_SIZE, extend the buffer.
-            if( fetchOffset > (size_t)(lex.buffer.size() - LexerImpl::BUFFER_SIZE/2) ){
+            if( fetchOffset > (size_t)(lex.buffer.size() - lex.BUFFER_SIZE/2) ){
                 if( lex.verbosity > 2 )
                     std::cout<< " Extending Buffer.\n";
 
                 // Move memory to the resized buffer, if the token starts later.
                 if( fetchOffset > 0 ){
                     // Create new buffer
-                    std::string tmp( lex.buffer.size() + (LexerImpl::BUFFER_SIZE / 2), '\0' );
+                    std::string tmp( lex.buffer.size() + (lex.BUFFER_SIZE / 2), '\0' );
 
                     // Move data to new buffer. bufferPointer points to start of the token.
                     std::memmove( &(tmp[0]), lex.bufferPointer, fetchOffset);
@@ -631,7 +644,7 @@ void LexerImpl::runner_dedicatedIteration( LexerImpl& lex ){
                     lex.buffer.assign( std::move( tmp ) );
                 }
                 else
-                    lex.buffer.resize(lex.buffer.size() + (LexerImpl::BUFFER_SIZE / 2), '\0');
+                    lex.buffer.resize(lex.buffer.size() + (lex.BUFFER_SIZE / 2), '\0');
 
                 // Mark this flag, for buffer eset after valid token is matched.
                 bufferWasExtended = true;

--- a/Grylloparse/src/lexer.cpp
+++ b/Grylloparse/src/lexer.cpp
@@ -140,11 +140,11 @@ public:
      *                   Must comply to the Lexer API.
      */ 
     LexerImpl( const RegLexData& lexicData, std::istream& strm, bool useBQ=false, 
-               const std::function< int(LexerImpl&, LexicToken&) >& getNxTk = 
-                     std::function< int(LexerImpl&, LexicToken&) >(),
                size_t _verbosity = DEFAULT_VERBOSITY, 
                bool _useDedicatedRunner = DEFAULT_UDR, 
-               size_t bufferSize = DEFAULT_BUFFSIZE )
+               size_t bufferSize = DEFAULT_BUFFSIZE,  
+               const std::function< int(LexerImpl&, LexicToken&) >& getNxTk = 
+                     std::function< int(LexerImpl&, LexicToken&) >() )
         : useBlockingQueue( useBQ ), useDedicatedLoopyTokenizer( _useDedicatedRunner ),
           BUFFER_SIZE( bufferSize ), verbosity( _verbosity ),
           lexics( lexicData ), rdr( strm ), 
@@ -153,11 +153,11 @@ public:
     { setFunctions(); }
 
     LexerImpl( RegLexData&& lexicData, std::istream& stream, bool useBQ = false,
-               std::function< int(LexerImpl&, LexicToken&) >&& getNxTk = 
-                    std::function< int(LexerImpl&, LexicToken&) >(),
                size_t _verbosity = DEFAULT_VERBOSITY, 
                bool _useDedicatedRunner = DEFAULT_UDR, 
-               size_t bufferSize = DEFAULT_BUFFSIZE ) 
+               size_t bufferSize = DEFAULT_BUFFSIZE,
+               std::function< int(LexerImpl&, LexicToken&) >&& getNxTk = 
+                    std::function< int(LexerImpl&, LexicToken&) >() ) 
         : useBlockingQueue( useBQ ), useDedicatedLoopyTokenizer( _useDedicatedRunner ),
           BUFFER_SIZE( bufferSize ), verbosity( _verbosity ),
           lexics( std::move(lexicData) ), rdr( stream ), 


### PR DESCRIPTION
Changed LexerImpl to use specifiable options of verbosity, buffer size, and Runner's implementation (dedicated or standard). These options are passed to constructor, but have default values.

Implemented benchmarks for LexerImpl's dedicated tokenizing runner and standard runner, which uses single-token getter getNextTokenPriv.

Conclusion based on benchmark results is that the dedicated runner is not faster than standard one. The execution times were basically the same with high buffer sizes.